### PR TITLE
Publish the MCP discovery file safely on Windows, and build its test there

### DIFF
--- a/src/slic3r/GUI/JusPrin/Mcp/McpDiscoveryFile.cpp
+++ b/src/slic3r/GUI/JusPrin/Mcp/McpDiscoveryFile.cpp
@@ -7,11 +7,14 @@
 #include <charconv>
 #include <cerrno>
 #include <chrono>
+#include <cstddef>
+#include <cstring>
 #include <ctime>
 #include <fstream>
 #include <iomanip>
 #include <mutex>
 #include <sstream>
+#include <vector>
 #ifdef _WIN32
 #include <windows.h>
 #else
@@ -110,6 +113,40 @@ std::string timestamp()
     out << std::put_time(&utc, "%Y-%m-%dT%H:%M:%SZ");
     return out.str();
 }
+
+#ifdef _WIN32
+// MoveFileExW cannot honour the atomicity this file promises: replacing a
+// target that any process holds open fails with ERROR_ACCESS_DENIED, and
+// readers hold it open constantly by design. Sharing delete access does not
+// help, because the ordinary rename still unlinks the name before the last
+// handle closes. FileRenameInfoEx with POSIX semantics is the rename that
+// behaves like rename(2) -- the name is rebound immediately while existing
+// handles keep reading the file they already opened.
+//
+// It needs NTFS and Windows 10 1607, so the caller falls back to the ordinary
+// replace rather than refusing to publish on a volume that cannot do this.
+bool rename_over_open_readers(const fs::path& temporary, const fs::path& path)
+{
+    const std::wstring target = path.wstring();
+    const std::size_t name_bytes = (target.size() + 1) * sizeof(wchar_t);
+    std::vector<std::byte> buffer(offsetof(FILE_RENAME_INFO, FileName) + name_bytes, std::byte{});
+    auto& info = *reinterpret_cast<FILE_RENAME_INFO*>(buffer.data());
+    info.Flags = FILE_RENAME_FLAG_REPLACE_IF_EXISTS | FILE_RENAME_FLAG_POSIX_SEMANTICS;
+    info.RootDirectory = nullptr;
+    info.FileNameLength = DWORD(target.size() * sizeof(wchar_t)); // bytes, excluding the terminator
+    std::memcpy(info.FileName, target.c_str(), name_bytes);
+
+    // DELETE is the access a rename needs; the share flags let readers keep the
+    // temporary open should anything have found it.
+    const HANDLE handle = CreateFileW(temporary.c_str(), DELETE | SYNCHRONIZE,
+                                      FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, nullptr, OPEN_EXISTING,
+                                      FILE_ATTRIBUTE_NORMAL, nullptr);
+    if (handle == INVALID_HANDLE_VALUE) return false;
+    const bool renamed = SetFileInformationByHandle(handle, FileRenameInfoEx, buffer.data(), DWORD(buffer.size())) != 0;
+    CloseHandle(handle);
+    return renamed;
+}
+#endif
 }
 
 std::string mcp_build_version()
@@ -186,7 +223,8 @@ DiscoveryRecord write_discovery(const fs::path& path, const std::string& url)
     output << body.dump(2) << '\n';
     output.close();
 #ifdef _WIN32
-    if (!MoveFileExW(temporary.c_str(), path.c_str(), MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH))
+    if (!rename_over_open_readers(temporary, path) &&
+        !MoveFileExW(temporary.c_str(), path.c_str(), MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH))
         throw fs::filesystem_error("Publish MCP discovery", temporary, path, std::error_code(GetLastError(), std::system_category()));
 #else
     fs::rename(temporary, path);

--- a/tests/agent/test_agent_bridge.cpp
+++ b/tests/agent/test_agent_bridge.cpp
@@ -1875,6 +1875,32 @@ TEST_CASE("mcp_connect reports a missing helper instead of writing settings", "[
     CHECK((*status)["payload"]["error"]["code"] == "helper_missing");
 }
 
+namespace {
+
+// The CLI is discovered by McpCatalog::command_on_path, which searches PATH for
+// the command name platform-dressed: "claude.exe" split on ';' under Windows,
+// bare "claude" split on ':' elsewhere. The fixture below has to match that
+// shape on both, or the search looks for a name the test never created.
+#ifdef _WIN32
+constexpr char kPathSeparator = ';';
+constexpr const char* kExecutableSuffix = ".exe";
+#else
+constexpr char kPathSeparator = ':';
+constexpr const char* kExecutableSuffix = "";
+#endif
+
+void set_path_env(const std::string& value)
+{
+#ifdef _WIN32
+    // setenv is POSIX; MSVC offers _putenv_s with the arguments reversed.
+    _putenv_s("PATH", value.c_str());
+#else
+    setenv("PATH", value.c_str(), 1);
+#endif
+}
+
+} // namespace
+
 TEST_CASE("mcp_connect runs an injected CLI runner", "[agent][mcp_setup]")
 {
     Harness harness;
@@ -1884,13 +1910,13 @@ TEST_CASE("mcp_connect runs an injected CLI runner", "[agent][mcp_setup]")
     std::filesystem::permissions(helper, std::filesystem::perms::owner_all);
     const auto bin = directory.root / "bin";
     std::filesystem::create_directories(bin);
-    const auto claude = bin / "claude";
+    const auto claude = bin / (std::string("claude") + kExecutableSuffix);
     { std::ofstream(claude) << "#!/bin/sh\n"; }
     std::filesystem::permissions(claude, std::filesystem::perms::owner_all);
     const char* previous = std::getenv("PATH");
     const std::string restored = previous ? previous : "";
-    const std::string path = bin.u8string() + ":" + restored;
-    setenv("PATH", path.c_str(), 1);
+    const std::string path = bin.u8string() + kPathSeparator + restored;
+    set_path_env(path);
     AgentHost::McpConnectSettings settings;
     settings.helper_path = helper.u8string();
     settings.launcher_path = helper.u8string();
@@ -1904,7 +1930,7 @@ TEST_CASE("mcp_connect runs an injected CLI runner", "[agent][mcp_setup]")
     });
     harness.handshake();
     harness.deliver("mcp_connect", json{{"toolId", "claude"}});
-    setenv("PATH", restored.c_str(), 1);
+    set_path_env(restored);
     REQUIRE(seen.size() >= 2);
     CHECK(seen[0] == claude.u8string());
     CHECK(std::find(seen.begin(), seen.end(), "--discovery") != seen.end());


### PR DESCRIPTION
Two Windows commits that were sitting unreviewed on a feature branch. Split out so they can be read on their own; the setup-screen work that was stacked on top of them is now #34, based on this branch.

## `a0d81826` — Build and run the MCP CLI-runner test on Windows

`tests/agent/test_agent_bridge.cpp` used `setenv` and a hardcoded `:` path separator, neither of which exists on MSVC, so the CLI-runner test did not compile on Windows. The fixture now dresses the command name per platform — `claude.exe` split on `;`, bare `claude` split on `:` — to match what `McpCatalog::command_on_path` actually searches for, and uses `_putenv_s` where `setenv` is unavailable.

## `edb0bcbe` — Publish MCP discovery without breaking on open readers

This is the substantive one, and it is a real Windows defect rather than a flake.

Replacing the discovery record used `MoveFileExW`, which fails with `ERROR_ACCESS_DENIED` the moment any process holds the target open. Readers hold it open constantly by design, so the publish did not merely race — it failed almost immediately, after a single read in a loop of fifty writes. Sharing delete access does not rescue an ordinary rename, and the `write_discovery` contract that a reader never sees a partial record could not be honoured on Windows at all.

The fix uses `FileRenameInfoEx` with POSIX semantics, which is the rename that behaves like `rename(2)`: the name is rebound at once while existing handles keep reading the file they already opened. It requires NTFS and Windows 10 1607, so a volume that cannot do it **falls back to the previous replace** rather than refusing to publish — those cases are left no worse than before, not silently broken in a new way.

Worth knowing why this stayed hidden: the failure was invisible until the test above made `agent_bridge_tests` compile on Windows. Once it did, the atomicity test took the whole process down — `write_discovery` threw, the throw escaped a scope holding a joinable reader thread, and `std::thread`'s destructor called `std::terminate`. Windows reports that as a bare `0xC0000409` fast-fail with no Catch2 output, so a genuine defect presented as a crashing test. That fragility is deliberately left alone here; it stops mattering once the publish succeeds, and fixing it would mix an unrelated concern into this change.

## Verification

- The atomicity test passed fifteen consecutive runs on Windows, having previously failed every one.
- Full `ctest`: one failure out of 414, the pre-existing `PlaceholderParser` segfault, which this does not touch and which reproduces identically on an untouched build.

## Review notes

Both files are fork-owned, so nothing here adds rebase burden against upstream OrcaSlicer.

The fallback path is the part most worth a second opinion: it means a non-NTFS volume keeps the old, broken-on-Windows behaviour rather than surfacing an error. That is the right call if the alternative is refusing to publish at all, but it does mean the contract is best-effort on those volumes rather than guaranteed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
